### PR TITLE
Fix issue with HiveOS displaying rigs as offline when the miner is not running correctly

### DIFF
--- a/hive-os/h-stats.sh
+++ b/hive-os/h-stats.sh
@@ -38,9 +38,15 @@ uptime=$(get_uptime)
 
 # Extract the most recent total khs value from the log
 total_khs=$(grep -oP "hashrate is: \K\d+.\d+" <<< "$log" | tail -n1)
+if [[ -z $total_khs ]]; then
+  total_khs=0
+fi
 
 # Count the number of blocks submitted successfully
 ac=$(grep -coP "Block submitted successfully!" <<< "$log")
+if [[ -z $ac ]]; then
+  ac=0
+fi
 
 rj=0
 ver="custom"


### PR DESCRIPTION
Made it so that the stats will always display at least 0 hashrate incase the miner is not properly configured or running. This prevents the rig from showing as offline in Hive.